### PR TITLE
Build using the build-script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,15 +16,11 @@ jobs:
           echo "/usr/lib/wine" >> $GITHUB_PATH
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup
-        run: meson setup ./build --cross-file ./build-wine64.txt --libdir lib --prefix /usr --buildtype release --strip
       - name: Build
-        run: ninja -C ./build
-      - name: Install
-        run: env DESTDIR="${PWD}" ninja -C ./build install
+        run: ./package-release.sh prod
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: wine-nvoptix
-          # TODO: fix defs and fakedlls being installed to weird locations
-          path: usr/lib/**
+          path: prod/nvoptix
+          if-no-files-found: error

--- a/package-release.sh
+++ b/package-release.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ -z "$1" ]; then
-  echo "Usage: package-release.sh destdir [--fakedlls]"
+  echo "Usage: package-release.sh destdir"
   exit 1
 fi
 
@@ -20,21 +20,15 @@ cd "$NVOPTIX_SRC_DIR"
 meson --cross-file "$NVOPTIX_SRC_DIR/build-wine64.txt"    \
         --buildtype "release"                             \
         --prefix "$NVOPTIX_BUILD_DIR/install"             \
-        --libdir="x64"                                    \
+        --libdir="lib"                                    \
         --strip                                           \
         "$NVOPTIX_BUILD_DIR/build"
 
 cd "$NVOPTIX_BUILD_DIR/build"
 ninja install
 
-mv "$NVOPTIX_BUILD_DIR/install/x64" "$NVOPTIX_BUILD_DIR"
-
-if [ "$2" == "--fakedlls" ]; then
-  mv "$NVOPTIX_BUILD_DIR/install/fakedlls" "$NVOPTIX_BUILD_DIR/fakedlls"
-else
-  rm -R "$NVOPTIX_BUILD_DIR/install/fakedlls"
-fi
-
+mv "$NVOPTIX_BUILD_DIR/install/lib" "$NVOPTIX_BUILD_DIR"
+mv "$NVOPTIX_BUILD_DIR/install/fakedll" "$NVOPTIX_BUILD_DIR"
 cp "$NVOPTIX_SRC_DIR/setup_nvoptix.sh" "$NVOPTIX_BUILD_DIR/setup_nvoptix.sh"
 chmod +x "$NVOPTIX_BUILD_DIR/setup_nvoptix.sh"
 rm -R "$NVOPTIX_BUILD_DIR/build"

--- a/setup_nvoptix.sh
+++ b/setup_nvoptix.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
 nvoptix_dir="$(dirname "$(readlink -fm "$0")")"
-lib='x64'
 wine='wine64'
 
-if [ ! -f "$nvoptix_dir/$lib/nvoptix.dll.so" ]; then
-    echo "nvoptix.dll.so not found in $nvoptix_dir/$lib" >&2
+if [ ! -f "$nvoptix_dir/lib/nvoptix.dll.so" ]; then
+    echo "nvoptix.dll.so not found in $nvoptix_dir/lib" >&2
     exit 1
 fi
 
@@ -85,7 +84,7 @@ function remove {
 
 function create {
     echo "    Installing nvoptix... "
-    ln -sf "$nvoptix_dir/$lib/$1.dll.so" "$unix_sys_path/$1.dll"
+    ln -sf "$nvoptix_dir/lib/$1.dll.so" "$unix_sys_path/$1.dll"
     if [ $? -ne 0 ]; then
         echo -e "Failed to create symlink"
         exit 1

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,7 +24,7 @@ nvoptix_dll_target = custom_target('nvoptix.dll',
   input   : [ 'nvoptix.spec', nvoptix_res_target ],
   command : [ winebuild, target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'nvoptix.dll' ],
   install : true,
-  install_dir : 'fakedlls')
+  install_dir : 'fakedll')
 
 
 nvoptix_def_target = custom_target('nvoptix.def',


### PR DESCRIPTION
Some changes to the buildscript putting the lib in /lib, and produce the fake dll in /fakedell (instead of fakedll***s*** since there is only one).

The archive then have those two folders + the setup script.
Changed the setup script to build fake fakedll unconditionally aswell.

I am not really sure there is much point in generating the .def file for the archive, since i would venture a guess and say that is purely for the more "specially interested" people, and they would most likely be able to build the project themselves if they need that for something.

PS. I am not opposed to doing the `x86_64-unix` / `x86_64-windows` approach either if you think that is better?