### PR TITLE
Silence meson warnings

### DIFF
--- a/build-wine64.txt
+++ b/build-wine64.txt
@@ -4,9 +4,11 @@ cpp = 'wineg++'
 ar = 'ar'
 strip = 'strip'
 
-[properties]
+[built-in options]
 c_args = ['-m64', '--no-gnu-unique', '-D__WINESRC__', '-Wno-attributes', '-Wno-implicit-function-declaration']
 c_link_args = ['-m64', '-mwindows']
+
+[properties]
 needs_exe_wrapper = true
 winelib = true
 


### PR DESCRIPTION
like:

DEPRECATION: c_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
DEPRECATION: c_link_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.