### PR TITLE
Fix internal linkage of functions

### DIFF
--- a/src/nvoptix.c
+++ b/src/nvoptix.c
@@ -34,6 +34,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(nvoptix);
 
+#include "nvoptix.h"
 #include "nvoptix_55.h"
 #include "nvoptix_47.h"
 #include "nvoptix_41.h"

--- a/src/nvoptix.h
+++ b/src/nvoptix.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 // opaque pointers, I'm assuming these stay the same no matter the ABI version
 
 typedef void *CUdeviceptr;
@@ -53,3 +55,7 @@ typedef struct OptixTask_t *OptixTask;
 // one last type that's a number but not an enum
 
 typedef unsigned long long OptixTraversableHandle;
+
+// declare a variable for our pointer to function from native libnvoptix.so
+
+extern OptixResult (*poptixQueryFunctionTable)(int abiId, unsigned int numOptions, void *optionKeys, const void **optionValues, void *functionTable, size_t sizeOfTable);

--- a/src/nvoptix_36.c
+++ b/src/nvoptix_36.c
@@ -34,7 +34,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(nvoptix);
 
-#include "nvoptix_types.h"
+#include "nvoptix.h"
 #include "nvoptix_36.h"
 
 static OptixFunctionTable_36 optixFunctionTable_36;

--- a/src/nvoptix_36.h
+++ b/src/nvoptix_36.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "nvoptix_types.h"
+#include "nvoptix.h"
 #include <stddef.h>
 
 // defensive duplicate of OptixDeviceContextOptions because I have to modify it
@@ -77,3 +77,5 @@ typedef struct OptixFunctionTable_36
     OptixResult (*optixDenoiserSetModel)(OptixDenoiser handle, int kind, void* data, size_t sizeInBytes);
     OptixResult (*optixDenoiserComputeIntensity)(OptixDenoiser handle, CUstream stream, const void *inputImage, CUdeviceptr outputIntensity, CUdeviceptr scratch, size_t scratchSizeInBytes);
 } OptixFunctionTable_36;
+
+OptixResult __cdecl optixQueryFunctionTable_36(unsigned int numOptions, int* optionKeys, const void** optionValues, void* functionTable, size_t sizeOfTable);

--- a/src/nvoptix_41.c
+++ b/src/nvoptix_41.c
@@ -34,7 +34,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(nvoptix);
 
-#include "nvoptix_types.h"
+#include "nvoptix.h"
 #include "nvoptix_41.h"
 
 static OptixFunctionTable_41 optixFunctionTable_41;

--- a/src/nvoptix_41.h
+++ b/src/nvoptix_41.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "nvoptix_types.h"
+#include "nvoptix.h"
 #include <stddef.h>
 
 // defensive duplicate of OptixDeviceContextOptions because I have to modify it
@@ -78,3 +78,5 @@ typedef struct OptixFunctionTable_41
     OptixResult (*optixDenoiserComputeIntensity)(OptixDenoiser handle, CUstream stream, const void *inputImage, CUdeviceptr outputIntensity, CUdeviceptr scratch, size_t scratchSizeInBytes);
     OptixResult (*optixDenoiserComputeAverageColor)(OptixDenoiser handle, CUstream stream, const void *inputImage, CUdeviceptr outputAverageColor, CUdeviceptr scratch, size_t scratchSizeInBytes);
 } OptixFunctionTable_41;
+
+OptixResult __cdecl optixQueryFunctionTable_41(unsigned int numOptions, int* optionKeys, const void** optionValues, void* functionTable, size_t sizeOfTable);

--- a/src/nvoptix_47.c
+++ b/src/nvoptix_47.c
@@ -34,7 +34,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(nvoptix);
 
-#include "nvoptix_types.h"
+#include "nvoptix.h"
 #include "nvoptix_47.h"
 
 static OptixFunctionTable_47 optixFunctionTable_47;

--- a/src/nvoptix_47.h
+++ b/src/nvoptix_47.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "nvoptix_types.h"
+#include "nvoptix.h"
 #include <stddef.h>
 
 // defensive duplicate of OptixDeviceContextOptions because I have to modify it
@@ -78,3 +78,5 @@ typedef struct OptixFunctionTable_47
     OptixResult (*optixDenoiserComputeAverageColor)(OptixDenoiser handle, CUstream stream, const void *inputImage, CUdeviceptr outputAverageColor, CUdeviceptr scratch, size_t scratchSizeInBytes);
     OptixResult (*optixDenoiserCreateWithUserModel)(OptixDeviceContext context, const void *data, size_t dataSizeInBytes, OptixDenoiser *returnHandle);
 } OptixFunctionTable_47;
+
+OptixResult __cdecl optixQueryFunctionTable_47(unsigned int numOptions, int* optionKeys, const void** optionValues, void* functionTable, size_t sizeOfTable);

--- a/src/nvoptix_55.c
+++ b/src/nvoptix_55.c
@@ -34,7 +34,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(nvoptix);
 
-#include "nvoptix_types.h"
+#include "nvoptix.h"
 #include "nvoptix_55.h"
 
 static OptixFunctionTable_55 optixFunctionTable_55;

--- a/src/nvoptix_55.h
+++ b/src/nvoptix_55.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "nvoptix_types.h"
+#include "nvoptix.h"
 #include <stddef.h>
 
 // defensive duplicate of OptixDeviceContextOptions because I have to modify it
@@ -83,3 +83,5 @@ typedef struct OptixFunctionTable_55
     OptixResult (*optixDenoiserComputeAverageColor)(OptixDenoiser handle, CUstream stream, const void *inputImage, CUdeviceptr outputAverageColor, CUdeviceptr scratch, size_t scratchSizeInBytes);
     OptixResult (*optixDenoiserCreateWithUserModel)(OptixDeviceContext context, const void *data, size_t dataSizeInBytes, OptixDenoiser *returnHandle);
 } OptixFunctionTable_55;
+
+OptixResult __cdecl optixQueryFunctionTable_55(unsigned int numOptions, int* optionKeys, const void** optionValues, void* functionTable, size_t sizeOfTable);


### PR DESCRIPTION
Also rename `nvoptix_types.h` to `nvoptix.h` because it's no longer just types.

This makes sample for ABI 55 work again. Unfortunately, ABI 36 sample indeed seems to be busted on driver version 510.54.

Related to / supersedes #5.