### PR TITLE
Use wine folder structure

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ project('nvoptix', ['c'])
 cpu_family = target_machine.cpu_family()
 
 include_path = include_directories('./include')
+install_dir = get_option('libdir') / 'wine'
 
 lib_dl      = declare_dependency(link_args: [ '-ldl' ])
 

--- a/package-release.sh
+++ b/package-release.sh
@@ -19,17 +19,15 @@ cd "$NVOPTIX_SRC_DIR"
 
 meson --cross-file "$NVOPTIX_SRC_DIR/build-wine64.txt"    \
         --buildtype "release"                             \
-        --prefix "$NVOPTIX_BUILD_DIR/install"             \
-        --libdir="lib"                                    \
+        --prefix "$NVOPTIX_BUILD_DIR"                     \
+        --libdir="lib64"                                  \
         --strip                                           \
         "$NVOPTIX_BUILD_DIR/build"
 
 cd "$NVOPTIX_BUILD_DIR/build"
 ninja install
 
-mv "$NVOPTIX_BUILD_DIR/install/lib" "$NVOPTIX_BUILD_DIR"
-mv "$NVOPTIX_BUILD_DIR/install/fakedll" "$NVOPTIX_BUILD_DIR"
 cp "$NVOPTIX_SRC_DIR/setup_nvoptix.sh" "$NVOPTIX_BUILD_DIR/setup_nvoptix.sh"
 chmod +x "$NVOPTIX_BUILD_DIR/setup_nvoptix.sh"
 rm -R "$NVOPTIX_BUILD_DIR/build"
-rm -R "$NVOPTIX_BUILD_DIR/install"
+rm -R "$NVOPTIX_BUILD_DIR/defs"

--- a/setup_nvoptix.sh
+++ b/setup_nvoptix.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-nvoptix_dir="$(dirname "$(readlink -fm "$0")")"
+nvoptix_dir="$(dirname "$(readlink -fm "$0")")/lib64/wine"
 wine='wine64'
 
-if [ ! -f "$nvoptix_dir/lib/nvoptix.dll.so" ]; then
-    echo "nvoptix.dll.so not found in $nvoptix_dir/lib" >&2
+if [ ! -f "$nvoptix_dir/x86_64-unix/nvoptix.dll.so" ]; then
+    echo "nvoptix.dll.so not found in $nvoptix_dir/x86_64-unix" >&2
     exit 1
 fi
 
@@ -84,7 +84,7 @@ function remove {
 
 function create {
     echo "    Installing nvoptix... "
-    ln -sf "$nvoptix_dir/lib/$1.dll.so" "$unix_sys_path/$1.dll"
+    ln -sf "$nvoptix_dir/x86_64-unix/$1.dll.so" "$unix_sys_path/$1.dll"
     if [ $? -ne 0 ]; then
         echo -e "Failed to create symlink"
         exit 1

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,10 @@ nvoptix_src = [
 ]
 
 thread_dep = dependency('threads')
+arch_dir_prefix = target_machine.cpu_family() == 'x86_64' ? 'x86_64-' : 'i386-'
+install_dir_unix = install_dir / arch_dir_prefix + 'unix'
+install_dir_windows = install_dir / arch_dir_prefix + 'windows'
+
 
 nvoptix_res_target = custom_target('nvoptix.res',
   output  : 'nvoptix.res',
@@ -20,7 +24,8 @@ nvoptix_dll = shared_library('nvoptix.dll', nvoptix_src,
   dependencies        : [ thread_dep, lib_dl ],
   include_directories : include_path,
   objects             : 'nvoptix.spec',
-  install             : true)
+  install             : true,
+  install_dir         : install_dir_unix)
 
 
 nvoptix_dll_target = custom_target('nvoptix.dll',
@@ -28,7 +33,7 @@ nvoptix_dll_target = custom_target('nvoptix.dll',
   input   : [ 'nvoptix.spec', nvoptix_res_target ],
   command : [ winebuild, target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'nvoptix.dll' ],
   install : true,
-  install_dir : 'fakedll')
+  install_dir : install_dir_windows)
 
 
 nvoptix_def_target = custom_target('nvoptix.def',


### PR DESCRIPTION
Since we do not use the x32/x64 folder structure anyway, might aswell use upstream wine folder structure when generating lib and fakedll.

Closes #9 