### PR TITLE
Remove non-existing struct value

### DIFF
--- a/src/nvoptix_22.h
+++ b/src/nvoptix_22.h
@@ -32,7 +32,6 @@ typedef struct OptixDeviceContextOptions_22
     OptixLogCallback_22 logCallbackFunction;
     void *logCallbackData;
     int logCallbackLevel;
-    int validationMode;
 } OptixDeviceContextOptions_22;
 
 // table as in public docs but stripped of most structures (pointers to which have been replaced with opaque `void*`)

--- a/src/nvoptix_36.h
+++ b/src/nvoptix_36.h
@@ -32,7 +32,6 @@ typedef struct OptixDeviceContextOptions_36
     OptixLogCallback_36 logCallbackFunction;
     void *logCallbackData;
     int logCallbackLevel;
-    int validationMode;
 } OptixDeviceContextOptions_36;
 
 // table as in public docs but stripped of most structures (pointers to which have been replaced with opaque `void*`)


### PR DESCRIPTION
ABI 22 and ABI 36 does not have the value for validationMode in the
OptixDeviceContextOptions struct.