### PR TITLE
Add support for log callbacks

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 nvoptix_src = [
   'nvoptix.c',
+  'nvoptix_callbacks.c',
   'nvoptix_55.c',
   'nvoptix_47.c',
   'nvoptix_41.c',

--- a/src/nvoptix.h
+++ b/src/nvoptix.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <pthread.h>
 
 // opaque pointers, I'm assuming these stay the same no matter the ABI version
 
@@ -64,3 +65,17 @@ typedef unsigned long long OptixTraversableHandle;
 // declare a variable for our pointer to function from native libnvoptix.so
 
 extern OptixResult (*poptixQueryFunctionTable)(int abiId, unsigned int numOptions, void *optionKeys, const void **optionValues, void *functionTable, size_t sizeOfTable);
+
+// callback support
+
+struct callback_t
+{
+    OptixLogCallback __attribute((ms_abi)) func;
+    void* data;
+};
+
+extern pthread_rwlock_t callbacks_lock;
+extern struct callback_t *callbacks;
+_Bool callbacks_enabled(void);
+void *wrap_callback(OptixLogCallback func, void *data);
+void log_callback(unsigned int level, const char *tag, const char *message, void *cbdata);

--- a/src/nvoptix.h
+++ b/src/nvoptix.h
@@ -53,6 +53,10 @@ typedef struct OptixPipeline_t *OptixPipeline;
 typedef struct OptixDenoiser_t *OptixDenoiser;
 typedef struct OptixTask_t *OptixTask;
 
+// callback signatures
+
+typedef void (*OptixLogCallback)(unsigned int level, const char *tag, const char *message, void *cbdata);
+
 // one last type that's a number but not an enum
 
 typedef unsigned long long OptixTraversableHandle;

--- a/src/nvoptix_22.c
+++ b/src/nvoptix_22.c
@@ -81,7 +81,7 @@ static OptixResult __cdecl optixDeviceContextGetProperty_22(OptixDeviceContext c
     return optixFunctionTable_22.optixDeviceContextGetProperty(context, property, value, sizeInBytes);
 }
 
-static OptixResult __cdecl optixDeviceContextSetLogCallback_22(OptixDeviceContext context, OptixLogCallback_22 callbackFunction, void *callbackData, unsigned int callbackLevel)
+static OptixResult __cdecl optixDeviceContextSetLogCallback_22(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel)
 {
     FIXME("(%p, %p, %p, %u): stub\n", context, callbackFunction, callbackData, callbackLevel);
     return OPTIX_SUCCESS;

--- a/src/nvoptix_22.c
+++ b/src/nvoptix_22.c
@@ -59,11 +59,18 @@ static OptixResult __cdecl optixDeviceContextCreate_22(CUcontext fromContext, co
 
     OptixDeviceContextOptions_22 opts = *options;
 
-    if (opts.logCallbackFunction || opts.logCallbackLevel)
+    if (opts.logCallbackFunction)
     {
-        FIXME("log callback not supported\n");
-        opts.logCallbackFunction = NULL;
-        opts.logCallbackLevel = 0;
+        if (callbacks_enabled())
+        {
+            opts.logCallbackData = wrap_callback(opts.logCallbackFunction, opts.logCallbackData);
+            opts.logCallbackFunction = log_callback;
+        }
+        else
+        {
+            WARN("log callbacks disabled\n");
+            opts.logCallbackFunction = NULL;
+        }
     }
 
     return optixFunctionTable_22.optixDeviceContextCreate(fromContext, &opts, context);
@@ -83,8 +90,23 @@ static OptixResult __cdecl optixDeviceContextGetProperty_22(OptixDeviceContext c
 
 static OptixResult __cdecl optixDeviceContextSetLogCallback_22(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel)
 {
-    FIXME("(%p, %p, %p, %u): stub\n", context, callbackFunction, callbackData, callbackLevel);
-    return OPTIX_SUCCESS;
+    TRACE("(%p, %p, %p, %u)\n", context, callbackFunction, callbackData, callbackLevel);
+
+    if (callbackFunction)
+    {
+        if (callbacks_enabled())
+        {
+            callbackData = wrap_callback(callbackFunction, callbackData);
+            callbackFunction = log_callback;
+        }
+        else
+        {
+            WARN("log callbacks disabled\n");
+            return OPTIX_SUCCESS;
+        }
+    }
+
+    return optixFunctionTable_22.optixDeviceContextSetLogCallback(context, callbackFunction, callbackData, callbackLevel);
 }
 
 static OptixResult __cdecl optixDeviceContextSetCacheEnabled_22(OptixDeviceContext context, int enabled)

--- a/src/nvoptix_22.h
+++ b/src/nvoptix_22.h
@@ -25,11 +25,9 @@
 
 // defensive duplicate of OptixDeviceContextOptions because I have to modify it
 
-typedef void (*OptixLogCallback_22)(unsigned int level, const char *tag, const char *message, void *cbdata);
-
 typedef struct OptixDeviceContextOptions_22
 {
-    OptixLogCallback_22 logCallbackFunction;
+    OptixLogCallback logCallbackFunction;
     void *logCallbackData;
     int logCallbackLevel;
 } OptixDeviceContextOptions_22;
@@ -43,7 +41,7 @@ typedef struct OptixFunctionTable_22
     OptixResult (*optixDeviceContextCreate)(CUcontext fromContext, const OptixDeviceContextOptions_22 *options, OptixDeviceContext *context);
     OptixResult (*optixDeviceContextDestroy)(OptixDeviceContext context);
     OptixResult (*optixDeviceContextGetProperty)(OptixDeviceContext context, int property, void *value, size_t sizeInBytes);
-    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback_22 callbackFunction, void *callbackData, unsigned int callbackLevel);
+    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel);
     OptixResult (*optixDeviceContextSetCacheEnabled)(OptixDeviceContext context, int enabled);
     OptixResult (*optixDeviceContextSetCacheLocation)(OptixDeviceContext context, const char *location);
     OptixResult (*optixDeviceContextSetCacheDatabaseSizes)(OptixDeviceContext context, size_t lowWaterMark, size_t highWaterMark);

--- a/src/nvoptix_36.c
+++ b/src/nvoptix_36.c
@@ -81,7 +81,7 @@ static OptixResult __cdecl optixDeviceContextGetProperty_36(OptixDeviceContext c
     return optixFunctionTable_36.optixDeviceContextGetProperty(context, property, value, sizeInBytes);
 }
 
-static OptixResult __cdecl optixDeviceContextSetLogCallback_36(OptixDeviceContext context, OptixLogCallback_36 callbackFunction, void *callbackData, unsigned int callbackLevel)
+static OptixResult __cdecl optixDeviceContextSetLogCallback_36(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel)
 {
     FIXME("(%p, %p, %p, %u): stub\n", context, callbackFunction, callbackData, callbackLevel);
     return OPTIX_SUCCESS;

--- a/src/nvoptix_36.c
+++ b/src/nvoptix_36.c
@@ -59,11 +59,18 @@ static OptixResult __cdecl optixDeviceContextCreate_36(CUcontext fromContext, co
 
     OptixDeviceContextOptions_36 opts = *options;
 
-    if (opts.logCallbackFunction || opts.logCallbackLevel)
+    if (opts.logCallbackFunction)
     {
-        FIXME("log callback not supported\n");
-        opts.logCallbackFunction = NULL;
-        opts.logCallbackLevel = 0;
+        if (callbacks_enabled())
+        {
+            opts.logCallbackData = wrap_callback(opts.logCallbackFunction, opts.logCallbackData);
+            opts.logCallbackFunction = log_callback;
+        }
+        else
+        {
+            WARN("log callbacks disabled\n");
+            opts.logCallbackFunction = NULL;
+        }
     }
 
     return optixFunctionTable_36.optixDeviceContextCreate(fromContext, &opts, context);
@@ -83,8 +90,23 @@ static OptixResult __cdecl optixDeviceContextGetProperty_36(OptixDeviceContext c
 
 static OptixResult __cdecl optixDeviceContextSetLogCallback_36(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel)
 {
-    FIXME("(%p, %p, %p, %u): stub\n", context, callbackFunction, callbackData, callbackLevel);
-    return OPTIX_SUCCESS;
+    TRACE("(%p, %p, %p, %u)\n", context, callbackFunction, callbackData, callbackLevel);
+
+    if (callbackFunction)
+    {
+        if (callbacks_enabled())
+        {
+            callbackData = wrap_callback(callbackFunction, callbackData);
+            callbackFunction = log_callback;
+        }
+        else
+        {
+            WARN("log callbacks disabled\n");
+            return OPTIX_SUCCESS;
+        }
+    }
+
+    return optixFunctionTable_36.optixDeviceContextSetLogCallback(context, callbackFunction, callbackData, callbackLevel);
 }
 
 static OptixResult __cdecl optixDeviceContextSetCacheEnabled_36(OptixDeviceContext context, int enabled)

--- a/src/nvoptix_36.h
+++ b/src/nvoptix_36.h
@@ -25,11 +25,9 @@
 
 // defensive duplicate of OptixDeviceContextOptions because I have to modify it
 
-typedef void (*OptixLogCallback_36)(unsigned int level, const char *tag, const char *message, void *cbdata);
-
 typedef struct OptixDeviceContextOptions_36
 {
-    OptixLogCallback_36 logCallbackFunction;
+    OptixLogCallback logCallbackFunction;
     void *logCallbackData;
     int logCallbackLevel;
 } OptixDeviceContextOptions_36;
@@ -43,7 +41,7 @@ typedef struct OptixFunctionTable_36
     OptixResult (*optixDeviceContextCreate)(CUcontext fromContext, const OptixDeviceContextOptions_36 *options, OptixDeviceContext *context);
     OptixResult (*optixDeviceContextDestroy)(OptixDeviceContext context);
     OptixResult (*optixDeviceContextGetProperty)(OptixDeviceContext context, int property, void *value, size_t sizeInBytes);
-    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback_36 callbackFunction, void *callbackData, unsigned int callbackLevel);
+    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel);
     OptixResult (*optixDeviceContextSetCacheEnabled)(OptixDeviceContext context, int enabled);
     OptixResult (*optixDeviceContextSetCacheLocation)(OptixDeviceContext context, const char *location);
     OptixResult (*optixDeviceContextSetCacheDatabaseSizes)(OptixDeviceContext context, size_t lowWaterMark, size_t highWaterMark);

--- a/src/nvoptix_41.c
+++ b/src/nvoptix_41.c
@@ -59,11 +59,18 @@ static OptixResult __cdecl optixDeviceContextCreate_41(CUcontext fromContext, co
 
     OptixDeviceContextOptions_41 opts = *options;
 
-    if (opts.logCallbackFunction || opts.logCallbackLevel)
+    if (opts.logCallbackFunction)
     {
-        FIXME("log callback not supported\n");
-        opts.logCallbackFunction = NULL;
-        opts.logCallbackLevel = 0;
+        if (callbacks_enabled())
+        {
+            opts.logCallbackData = wrap_callback(opts.logCallbackFunction, opts.logCallbackData);
+            opts.logCallbackFunction = log_callback;
+        }
+        else
+        {
+            WARN("log callbacks disabled\n");
+            opts.logCallbackFunction = NULL;
+        }
     }
 
     return optixFunctionTable_41.optixDeviceContextCreate(fromContext, &opts, context);
@@ -83,8 +90,23 @@ static OptixResult __cdecl optixDeviceContextGetProperty_41(OptixDeviceContext c
 
 static OptixResult __cdecl optixDeviceContextSetLogCallback_41(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel)
 {
-    FIXME("(%p, %p, %p, %u): stub\n", context, callbackFunction, callbackData, callbackLevel);
-    return OPTIX_SUCCESS;
+    TRACE("(%p, %p, %p, %u)\n", context, callbackFunction, callbackData, callbackLevel);
+
+    if (callbackFunction)
+    {
+        if (callbacks_enabled())
+        {
+            callbackData = wrap_callback(callbackFunction, callbackData);
+            callbackFunction = log_callback;
+        }
+        else
+        {
+            WARN("log callbacks disabled\n");
+            return OPTIX_SUCCESS;
+        }
+    }
+
+    return optixFunctionTable_41.optixDeviceContextSetLogCallback(context, callbackFunction, callbackData, callbackLevel);
 }
 
 static OptixResult __cdecl optixDeviceContextSetCacheEnabled_41(OptixDeviceContext context, int enabled)

--- a/src/nvoptix_41.c
+++ b/src/nvoptix_41.c
@@ -81,7 +81,7 @@ static OptixResult __cdecl optixDeviceContextGetProperty_41(OptixDeviceContext c
     return optixFunctionTable_41.optixDeviceContextGetProperty(context, property, value, sizeInBytes);
 }
 
-static OptixResult __cdecl optixDeviceContextSetLogCallback_41(OptixDeviceContext context, OptixLogCallback_41 callbackFunction, void *callbackData, unsigned int callbackLevel)
+static OptixResult __cdecl optixDeviceContextSetLogCallback_41(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel)
 {
     FIXME("(%p, %p, %p, %u): stub\n", context, callbackFunction, callbackData, callbackLevel);
     return OPTIX_SUCCESS;

--- a/src/nvoptix_41.h
+++ b/src/nvoptix_41.h
@@ -25,11 +25,9 @@
 
 // defensive duplicate of OptixDeviceContextOptions because I have to modify it
 
-typedef void (*OptixLogCallback_41)(unsigned int level, const char *tag, const char *message, void *cbdata);
-
 typedef struct OptixDeviceContextOptions_41
 {
-    OptixLogCallback_41 logCallbackFunction;
+    OptixLogCallback logCallbackFunction;
     void *logCallbackData;
     int logCallbackLevel;
     int validationMode;
@@ -44,7 +42,7 @@ typedef struct OptixFunctionTable_41
     OptixResult (*optixDeviceContextCreate)(CUcontext fromContext, const OptixDeviceContextOptions_41 *options, OptixDeviceContext *context);
     OptixResult (*optixDeviceContextDestroy)(OptixDeviceContext context);
     OptixResult (*optixDeviceContextGetProperty)(OptixDeviceContext context, int property, void *value, size_t sizeInBytes);
-    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback_41 callbackFunction, void *callbackData, unsigned int callbackLevel);
+    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel);
     OptixResult (*optixDeviceContextSetCacheEnabled)(OptixDeviceContext context, int enabled);
     OptixResult (*optixDeviceContextSetCacheLocation)(OptixDeviceContext context, const char *location);
     OptixResult (*optixDeviceContextSetCacheDatabaseSizes)(OptixDeviceContext context, size_t lowWaterMark, size_t highWaterMark);

--- a/src/nvoptix_47.c
+++ b/src/nvoptix_47.c
@@ -81,7 +81,7 @@ static OptixResult __cdecl optixDeviceContextGetProperty_47(OptixDeviceContext c
     return optixFunctionTable_47.optixDeviceContextGetProperty(context, property, value, sizeInBytes);
 }
 
-static OptixResult __cdecl optixDeviceContextSetLogCallback_47(OptixDeviceContext context, OptixLogCallback_47 callbackFunction, void *callbackData, unsigned int callbackLevel)
+static OptixResult __cdecl optixDeviceContextSetLogCallback_47(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel)
 {
     FIXME("(%p, %p, %p, %u): stub\n", context, callbackFunction, callbackData, callbackLevel);
     return OPTIX_SUCCESS;

--- a/src/nvoptix_47.h
+++ b/src/nvoptix_47.h
@@ -25,11 +25,9 @@
 
 // defensive duplicate of OptixDeviceContextOptions because I have to modify it
 
-typedef void (*OptixLogCallback_47)(unsigned int level, const char *tag, const char *message, void *cbdata);
-
 typedef struct OptixDeviceContextOptions_47
 {
-    OptixLogCallback_47 logCallbackFunction;
+    OptixLogCallback logCallbackFunction;
     void *logCallbackData;
     int logCallbackLevel;
     int validationMode;
@@ -44,7 +42,7 @@ typedef struct OptixFunctionTable_47
     OptixResult (*optixDeviceContextCreate)(CUcontext fromContext, const OptixDeviceContextOptions_47 *options, OptixDeviceContext *context);
     OptixResult (*optixDeviceContextDestroy)(OptixDeviceContext context);
     OptixResult (*optixDeviceContextGetProperty)(OptixDeviceContext context, int property, void *value, size_t sizeInBytes);
-    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback_47 callbackFunction, void *callbackData, unsigned int callbackLevel);
+    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel);
     OptixResult (*optixDeviceContextSetCacheEnabled)(OptixDeviceContext context, int enabled);
     OptixResult (*optixDeviceContextSetCacheLocation)(OptixDeviceContext context, const char *location);
     OptixResult (*optixDeviceContextSetCacheDatabaseSizes)(OptixDeviceContext context, size_t lowWaterMark, size_t highWaterMark);

--- a/src/nvoptix_55.c
+++ b/src/nvoptix_55.c
@@ -59,11 +59,18 @@ static OptixResult __cdecl optixDeviceContextCreate_55(CUcontext fromContext, co
 
     OptixDeviceContextOptions_55 opts = *options;
 
-    if (opts.logCallbackFunction || opts.logCallbackLevel)
+    if (opts.logCallbackFunction)
     {
-        FIXME("log callback not supported\n");
-        opts.logCallbackFunction = NULL;
-        opts.logCallbackLevel = 0;
+        if (callbacks_enabled())
+        {
+            opts.logCallbackData = wrap_callback(opts.logCallbackFunction, opts.logCallbackData);
+            opts.logCallbackFunction = log_callback;
+        }
+        else
+        {
+            WARN("log callbacks disabled\n");
+            opts.logCallbackFunction = NULL;
+        }
     }
 
     return optixFunctionTable_55.optixDeviceContextCreate(fromContext, &opts, context);
@@ -83,8 +90,23 @@ static OptixResult __cdecl optixDeviceContextGetProperty_55(OptixDeviceContext c
 
 static OptixResult __cdecl optixDeviceContextSetLogCallback_55(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel)
 {
-    FIXME("(%p, %p, %p, %u): stub\n", context, callbackFunction, callbackData, callbackLevel);
-    return OPTIX_SUCCESS;
+    TRACE("(%p, %p, %p, %u)\n", context, callbackFunction, callbackData, callbackLevel);
+
+    if (callbackFunction)
+    {
+        if (callbacks_enabled())
+        {
+            callbackData = wrap_callback(callbackFunction, callbackData);
+            callbackFunction = log_callback;
+        }
+        else
+        {
+            WARN("log callbacks disabled\n");
+            return OPTIX_SUCCESS;
+        }
+    }
+
+    return optixFunctionTable_55.optixDeviceContextSetLogCallback(context, callbackFunction, callbackData, callbackLevel);
 }
 
 static OptixResult __cdecl optixDeviceContextSetCacheEnabled_55(OptixDeviceContext context, int enabled)

--- a/src/nvoptix_55.c
+++ b/src/nvoptix_55.c
@@ -81,7 +81,7 @@ static OptixResult __cdecl optixDeviceContextGetProperty_55(OptixDeviceContext c
     return optixFunctionTable_55.optixDeviceContextGetProperty(context, property, value, sizeInBytes);
 }
 
-static OptixResult __cdecl optixDeviceContextSetLogCallback_55(OptixDeviceContext context, OptixLogCallback_55 callbackFunction, void *callbackData, unsigned int callbackLevel)
+static OptixResult __cdecl optixDeviceContextSetLogCallback_55(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel)
 {
     FIXME("(%p, %p, %p, %u): stub\n", context, callbackFunction, callbackData, callbackLevel);
     return OPTIX_SUCCESS;

--- a/src/nvoptix_55.h
+++ b/src/nvoptix_55.h
@@ -25,11 +25,9 @@
 
 // defensive duplicate of OptixDeviceContextOptions because I have to modify it
 
-typedef void (*OptixLogCallback_55)(unsigned int level, const char *tag, const char *message, void *cbdata);
-
 typedef struct OptixDeviceContextOptions_55
 {
-    OptixLogCallback_55 logCallbackFunction;
+    OptixLogCallback logCallbackFunction;
     void *logCallbackData;
     int logCallbackLevel;
     int validationMode;
@@ -44,7 +42,7 @@ typedef struct OptixFunctionTable_55
     OptixResult (*optixDeviceContextCreate)(CUcontext fromContext, const OptixDeviceContextOptions_55 *options, OptixDeviceContext *context);
     OptixResult (*optixDeviceContextDestroy)(OptixDeviceContext context);
     OptixResult (*optixDeviceContextGetProperty)(OptixDeviceContext context, int property, void *value, size_t sizeInBytes);
-    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback_55 callbackFunction, void *callbackData, unsigned int callbackLevel);
+    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel);
     OptixResult (*optixDeviceContextSetCacheEnabled)(OptixDeviceContext context, int enabled);
     OptixResult (*optixDeviceContextSetCacheLocation)(OptixDeviceContext context, const char *location);
     OptixResult (*optixDeviceContextSetCacheDatabaseSizes)(OptixDeviceContext context, size_t lowWaterMark, size_t highWaterMark);

--- a/src/nvoptix_callbacks.c
+++ b/src/nvoptix_callbacks.c
@@ -1,0 +1,105 @@
+#include "windef.h"
+#include "winbase.h"
+#include "wine/debug.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(nvoptix);
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#include "nvoptix.h"
+
+pthread_rwlock_t callbacks_lock;
+struct callback_t *callbacks = NULL;
+static ptrdiff_t callbacks_count = 0;
+
+_Bool callbacks_enabled(void)
+{
+    static int enabled = -1;
+
+    if (enabled == -1)
+    {
+        char *env = getenv("WINE_NVOPTIX_CALLBACKS");
+
+        if (env)
+        {
+            enabled = atoi(env) ? 1 : 0;
+
+            if (!enabled) WARN("Log callbacks disabled\n");
+        }
+        else
+        {
+            enabled = 1;
+        }
+    }
+
+    return enabled;
+}
+
+void *wrap_callback(OptixLogCallback func, void *data)
+{
+    if (pthread_rwlock_wrlock(&callbacks_lock))
+    {
+        ERR("(%p, %p): Failed to acquire writer lock\n", func, data);
+        return (void*)~(ptrdiff_t)0;
+    }
+
+    struct callback_t *new_callbacks = reallocarray(
+        callbacks, callbacks_count + 1, sizeof(struct callback_t));
+
+    if (!new_callbacks)
+    {
+        ERR("(%p, %p): Failed to reallocate callbacks array\n", func, data);
+
+        if (pthread_rwlock_unlock(&callbacks_lock))
+            ERR("(%p, %p): Failed to release writer lock\n", func, data);
+
+        return (void*)~(ptrdiff_t)0;
+    }
+
+    callbacks = new_callbacks;
+
+    struct callback_t *callback = &callbacks[callbacks_count];
+
+    *(void**)&callback->func = func;
+    callback->data = data;
+
+    ptrdiff_t offset = callbacks_count++;
+
+    if (pthread_rwlock_unlock(&callbacks_lock))
+        ERR("(%p, %p): Failed to release writer lock\n", func, data);
+
+    TRACE("(%p, %p) = %td\n", func, data, offset);
+
+    return (void*)offset;
+}
+
+void log_callback(unsigned int level, const char *tag, const char *message, void *cbdata)
+{
+    TRACE("(%u, %s, %p, %p)\n", level, tag, message, cbdata);
+
+    ptrdiff_t offset = (ptrdiff_t)cbdata;
+
+    if (offset < 0 || offset >= callbacks_count)
+    {
+        ERR("Failed to find callback for offset = %td\n", offset);
+        return;
+    }
+
+    if (pthread_rwlock_rdlock(&callbacks_lock))
+    {
+        ERR("Failed to acquire reader lock for offset = %td\n", offset);
+        return;
+    }
+
+    struct callback_t *callback = &callbacks[offset];
+
+    OptixLogCallback __attribute((ms_abi)) func = callback->func;
+    void *data = callback->data;
+
+    if (pthread_rwlock_unlock(&callbacks_lock))
+        ERR("Failed to release reader lock for offset = %td\n", offset);
+
+    func(level, tag, message, data);
+}


### PR DESCRIPTION
Synchronization is hard :weary:

Enable with `WINE_NVOPTIX_CALLBACKS=1` in environment. At least doesn't crash NV samples, but I have no idea if this code is correct; even though they do register callbacks, Optix apparently never calls them.

Can you test it with DAZ Studio?