### PR TITLE
Abi60

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           apt-get update && apt-get -y upgrade
           apt-get install -y software-properties-common
-          add-apt-repository -y ppa:cybermax-dexter/meson-backport
+          add-apt-repository -y ppa:savoury1/build-tools
           apt-get update && apt-get -y upgrade
           apt-get install -y --no-install-recommends meson ninja-build wine64-tools
           echo "/usr/lib/wine" >> $GITHUB_PATH

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 nvoptix_src = [
   'nvoptix.c',
   'nvoptix_callbacks.c',
+  'nvoptix_60.c',
   'nvoptix_55.c',
   'nvoptix_47.c',
   'nvoptix_41.c',

--- a/src/nvoptix.c
+++ b/src/nvoptix.c
@@ -37,6 +37,7 @@
 WINE_DEFAULT_DEBUG_CHANNEL(nvoptix);
 
 #include "nvoptix.h"
+#include "nvoptix_60.h"
 #include "nvoptix_55.h"
 #include "nvoptix_47.h"
 #include "nvoptix_41.h"
@@ -46,7 +47,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(nvoptix);
 static void *libnvoptix_handle = NULL;
 OptixResult (*poptixQueryFunctionTable)(int abiId, unsigned int numOptions, void *optionKeys, const void **optionValues, void *functionTable, size_t sizeOfTable) = NULL;
 
-#define OPTIX_MAX_ABI_VERSION 55
+#define OPTIX_MAX_ABI_VERSION 60
 
 OptixResult __cdecl optixQueryFunctionTable(
     int abiId,
@@ -77,15 +78,17 @@ OptixResult __cdecl optixQueryFunctionTable(
         ERR("abiId = %d > %d not supported\n", abiId, OPTIX_MAX_ABI_VERSION);
         return OPTIX_ERROR_UNSUPPORTED_ABI_VERSION;
     }
-    else if (sizeOfTable > sizeof(OptixFunctionTable_55))
+    else if (sizeOfTable > sizeof(OptixFunctionTable_60))
     {
-        ERR("sizeOfTable = %zu > %zu not supported\n", sizeOfTable, sizeof(OptixFunctionTable_55));
+        ERR("sizeOfTable = %zu > %zu not supported\n", sizeOfTable, sizeof(OptixFunctionTable_60));
         return OPTIX_ERROR_FUNCTION_TABLE_SIZE_MISMATCH;
     }
 
     switch (abiId)
     {
         // TODO: add other ABI versions here
+        case 60:
+            return optixQueryFunctionTable_60(numOptions, optionKeys, optionValues, functionTable, sizeOfTable);
         case 55:
             return optixQueryFunctionTable_55(numOptions, optionKeys, optionValues, functionTable, sizeOfTable);
         case 47:

--- a/src/nvoptix.h
+++ b/src/nvoptix.h
@@ -43,6 +43,10 @@ typedef enum OptixResult
     OPTIX_ERROR_INVALID_ENTRY_FUNCTION_OPTIONS = 7803,
     OPTIX_ERROR_LIBRARY_NOT_FOUND = 7804,
     OPTIX_ERROR_ENTRY_SYMBOL_NOT_FOUND = 7805,
+    OPTIX_ERROR_DEVICE_OUT_OF_MEMORY = 7807,
+    OPTIX_ERROR_CUDA_ERROR  = 7900,
+    OPTIX_ERROR_INTERNAL_ERROR = 7990,
+    OPTIX_ERROR_UNKNOWN = 7999,
 } OptixResult;
 
 // opaque pointers, I'm assuming these stay the same no matter the ABI version

--- a/src/nvoptix.rc
+++ b/src/nvoptix.rc
@@ -29,10 +29,10 @@
 #define WINE_FILENAME_STR "nvoptix.dll"
 #define WINE_FILEDESCRIPTION_STR "NVIDIA OptiX Ray Tracing Engine"
 
-#define WINE_FILEVERSION      7,4,0,0
-#define WINE_FILEVERSION_STR "7.4.0.0"
+#define WINE_FILEVERSION      7,5,0,0
+#define WINE_FILEVERSION_STR "7.5.0.0"
 
-#define WINE_PRODUCTVERSION      7,4,0,0
-#define WINE_PRODUCTVERSION_STR "7.4.0.0"
+#define WINE_PRODUCTVERSION      7,5,0,0
+#define WINE_PRODUCTVERSION_STR "7.5.0.0"
 
 #include "wine/wine_common_ver.rc"

--- a/src/nvoptix_60.c
+++ b/src/nvoptix_60.c
@@ -1,0 +1,423 @@
+/*
+ * MIT License
+ * Copyright (C) 2022 Sveinar Søpler
+ * Copyright (C) 2022 Krzysztof Bogacki
+ * Copyright (C) 2022 Timothée Barral
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <dlfcn.h>
+#include <stdarg.h>
+
+#include "windef.h"
+#include "winbase.h"
+#include "winnls.h"
+#include "wine/debug.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(nvoptix);
+
+#include "nvoptix.h"
+#include "nvoptix_60.h"
+
+static OptixFunctionTable_60 optixFunctionTable_60;
+
+/* OptiX ABI = 60 / SDK 7.5.0 */
+
+static const char *__cdecl optixGetErrorName_60(OptixResult result)
+{
+    TRACE("(%d)\n", result);
+    return optixFunctionTable_60.optixGetErrorName(result);
+}
+
+static const char *__cdecl optixGetErrorString_60(OptixResult result)
+{
+    TRACE("(%d)\n", result);
+    return optixFunctionTable_60.optixGetErrorString(result);
+}
+
+static OptixResult __cdecl optixDeviceContextCreate_60(CUcontext fromContext, const OptixDeviceContextOptions_60 *options, OptixDeviceContext *context)
+{
+    TRACE("(%p, %p, %p)\n", fromContext, options, context);
+
+    OptixDeviceContextOptions_60 opts = *options;
+
+    if (opts.logCallbackFunction)
+    {
+        if (callbacks_enabled())
+        {
+            opts.logCallbackData = wrap_callback(opts.logCallbackFunction, opts.logCallbackData);
+            opts.logCallbackFunction = log_callback;
+        }
+        else
+        {
+            WARN("log callbacks disabled\n");
+            opts.logCallbackFunction = NULL;
+        }
+    }
+
+    return optixFunctionTable_60.optixDeviceContextCreate(fromContext, &opts, context);
+}
+
+static OptixResult __cdecl optixDeviceContextDestroy_60(OptixDeviceContext context)
+{
+    TRACE("(%p)\n", context);
+    return optixFunctionTable_60.optixDeviceContextDestroy(context);
+}
+
+static OptixResult __cdecl optixDeviceContextGetProperty_60(OptixDeviceContext context, int property, void *value, size_t sizeInBytes)
+{
+    TRACE("(%p, %d, %p, %zu)\n", context, property, value, sizeInBytes);
+    return optixFunctionTable_60.optixDeviceContextGetProperty(context, property, value, sizeInBytes);
+}
+
+static OptixResult __cdecl optixDeviceContextSetLogCallback_60(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel)
+{
+    TRACE("(%p, %p, %p, %u)\n", context, callbackFunction, callbackData, callbackLevel);
+
+    if (callbackFunction)
+    {
+        if (callbacks_enabled())
+        {
+            callbackData = wrap_callback(callbackFunction, callbackData);
+            callbackFunction = log_callback;
+        }
+        else
+        {
+            WARN("log callbacks disabled\n");
+            return OPTIX_SUCCESS;
+        }
+    }
+
+    return optixFunctionTable_60.optixDeviceContextSetLogCallback(context, callbackFunction, callbackData, callbackLevel);
+}
+
+static OptixResult __cdecl optixDeviceContextSetCacheEnabled_60(OptixDeviceContext context, int enabled)
+{
+    TRACE("(%p, %d)\n", context, enabled);
+    return optixFunctionTable_60.optixDeviceContextSetCacheEnabled(context, enabled);
+}
+
+static OptixResult __cdecl optixDeviceContextSetCacheLocation_60(OptixDeviceContext context, const char *location)
+{
+    TRACE("(%p, %s)\n", context, location);
+
+    if (!location) return OPTIX_ERROR_DISK_CACHE_INVALID_PATH;
+
+    WCHAR location_wide[MAX_PATH];
+
+    MultiByteToWideChar(CP_ACP, 0, location, -1, location_wide, ARRAY_SIZE(location_wide));
+
+    char *unix_location = wine_get_unix_file_name(location_wide);
+
+    OptixResult result = optixFunctionTable_60.optixDeviceContextSetCacheLocation(context, unix_location);
+
+    HeapFree(GetProcessHeap(), 0, unix_location);
+
+    return result;
+}
+
+static OptixResult __cdecl optixDeviceContextSetCacheDatabaseSizes_60(OptixDeviceContext context, size_t lowWaterMark, size_t highWaterMark)
+{
+    TRACE("(%p, %zu, %zu)\n", context, lowWaterMark, highWaterMark);
+    return optixFunctionTable_60.optixDeviceContextSetCacheDatabaseSizes(context, lowWaterMark, highWaterMark);
+}
+
+static OptixResult __cdecl optixDeviceContextGetCacheEnabled_60(OptixDeviceContext context, int *enabled)
+{
+    TRACE("(%p, %p)\n", context, enabled);
+    return optixFunctionTable_60.optixDeviceContextGetCacheEnabled(context, enabled);
+}
+
+static OptixResult __cdecl optixDeviceContextGetCacheLocation_60(OptixDeviceContext context, char *location, size_t locationSize)
+{
+    TRACE("(%p, %p, %zu)\n", context, location, locationSize);
+
+    OptixResult result = optixFunctionTable_60.optixDeviceContextGetCacheLocation(context, location, locationSize);
+
+    if (result != OPTIX_SUCCESS) return result;
+
+    WCHAR *dos_location = wine_get_dos_file_name(location);
+
+    if (!WideCharToMultiByte(CP_ACP, 0, dos_location, -1, location, locationSize, NULL, NULL)) result = OPTIX_ERROR_INVALID_VALUE;
+
+    HeapFree(GetProcessHeap(), 0, dos_location);
+
+    return result;
+}
+
+static OptixResult __cdecl optixDeviceContextGetCacheDatabaseSizes_60(OptixDeviceContext context, size_t *lowWaterMark, size_t *highWaterMark)
+{
+    TRACE("(%p, %p, %p)\n", context, lowWaterMark, highWaterMark);
+    return optixFunctionTable_60.optixDeviceContextGetCacheDatabaseSizes(context, lowWaterMark, highWaterMark);
+}
+
+static OptixResult __cdecl optixModuleCreateFromPTX_60(OptixDeviceContext context, const void *moduleCompileOptions, const void *pipelineCompileOptions, const char *PTX, size_t PTXsize, char *logString, size_t *logStringSize, OptixModule *module)
+{
+    TRACE("(%p, %p, %p, %p, %zu, %p, %p, %p)\n", context, moduleCompileOptions, pipelineCompileOptions, PTX, PTXsize, logString, logStringSize, module);
+    return optixFunctionTable_60.optixModuleCreateFromPTX(context, moduleCompileOptions, pipelineCompileOptions, PTX, PTXsize, logString, logStringSize, module);
+}
+
+static OptixResult __cdecl optixModuleCreateFromPTXWithTasks_60(OptixDeviceContext context, const void *moduleCompileOptions, const void *pipelineCompileOptions, const char *PTX, size_t PTXsize, char *logString, size_t *logStringSize, OptixModule *module, OptixTask *firstTask)
+{
+    TRACE("(%p, %p, %p, %p, %zu, %p, %p, %p, %p)\n", context, moduleCompileOptions, pipelineCompileOptions, PTX, PTXsize, logString, logStringSize, module, firstTask);
+    return optixFunctionTable_60.optixModuleCreateFromPTXWithTasks(context, moduleCompileOptions, pipelineCompileOptions, PTX, PTXsize, logString, logStringSize, module, firstTask);
+}
+
+static OptixResult __cdecl optixModuleGetCompilationState_60(OptixModule module, int *state)
+{
+    TRACE("(%p, %p)\n", module, state);
+    return optixFunctionTable_60.optixModuleGetCompilationState(module, state);
+}
+
+static OptixResult __cdecl optixModuleDestroy_60(OptixModule module)
+{
+    TRACE("(%p)\n", module);
+    return optixFunctionTable_60.optixModuleDestroy(module);
+}
+
+static OptixResult __cdecl optixBuiltinISModuleGet_60(OptixDeviceContext context, const void *moduleCompileOptions, const void *pipelineCompileOptions, const void *builtinISOptions, OptixModule *builtinModule)
+{
+    TRACE("(%p, %p, %p, %p, %p)\n", context, moduleCompileOptions, pipelineCompileOptions, builtinISOptions, builtinModule);
+    return optixFunctionTable_60.optixBuiltinISModuleGet(context, moduleCompileOptions, pipelineCompileOptions, builtinISOptions, builtinModule);
+}
+
+static OptixResult __cdecl optixTaskExecute_60(OptixTask task, OptixTask *additionalTasks, unsigned int maxNumAdditionalTasks, unsigned int *numAdditionalTasksCreated)
+{
+    TRACE("(%p, %p, %u, %p)\n", task, additionalTasks, maxNumAdditionalTasks, numAdditionalTasksCreated);
+    return optixFunctionTable_60.optixTaskExecute(task, additionalTasks, maxNumAdditionalTasks, numAdditionalTasksCreated);
+}
+
+static OptixResult __cdecl optixProgramGroupCreate_60(OptixDeviceContext context, const void *programDescriptions, unsigned int numProgramGroups, const void *options, char *logString, size_t *logStringSize, OptixProgramGroup *programGroups)
+{
+    TRACE("(%p, %p, %u, %p, %p, %p, %p)\n", context, programDescriptions, numProgramGroups, options, logString, logStringSize, programGroups);
+    return optixFunctionTable_60.optixProgramGroupCreate(context, programDescriptions, numProgramGroups, options, logString, logStringSize, programGroups);
+}
+
+static OptixResult __cdecl optixProgramGroupDestroy_60(OptixProgramGroup programGroup)
+{
+    TRACE("(%p)\n", programGroup);
+    return optixFunctionTable_60.optixProgramGroupDestroy(programGroup);
+}
+
+static OptixResult __cdecl optixProgramGroupGetStackSize_60(OptixProgramGroup programGroup, void *stackSizes)
+{
+    TRACE("(%p, %p)\n", programGroup, stackSizes);
+    return optixFunctionTable_60.optixProgramGroupGetStackSize(programGroup, stackSizes);
+}
+
+static OptixResult __cdecl optixPipelineCreate_60(OptixDeviceContext context, const void *pipelineCompileOptions, const void *pipelineLinkOptions, const OptixProgramGroup *programGroups, unsigned int numProgramGroups, char *logString, size_t *logStringSize, OptixPipeline *pipeline)
+{
+    TRACE("(%p, %p, %p, %p, %u, %p, %p, %p)\n", context, pipelineCompileOptions, pipelineLinkOptions, programGroups, numProgramGroups, logString, logStringSize, pipeline);
+    return optixFunctionTable_60.optixPipelineCreate(context, pipelineCompileOptions, pipelineLinkOptions, programGroups, numProgramGroups, logString, logStringSize, pipeline);
+}
+
+static OptixResult __cdecl optixPipelineDestroy_60(OptixPipeline pipeline)
+{
+    TRACE("(%p)\n", pipeline);
+    return optixFunctionTable_60.optixPipelineDestroy(pipeline);
+}
+
+static OptixResult __cdecl optixPipelineSetStackSize_60(OptixPipeline pipeline, unsigned int directCallableStackSizeFromTraversal, unsigned int directCallableStackSizeFromState, unsigned int continuationStackSize, unsigned int maxTraversableGraphDepth)
+{
+    TRACE("(%p, %u, %u, %u, %u)\n", pipeline, directCallableStackSizeFromTraversal, directCallableStackSizeFromState, continuationStackSize, maxTraversableGraphDepth);
+    return optixFunctionTable_60.optixPipelineSetStackSize(pipeline, directCallableStackSizeFromTraversal, directCallableStackSizeFromState, continuationStackSize, maxTraversableGraphDepth);
+}
+
+static OptixResult __cdecl optixAccelComputeMemoryUsage_60(OptixDeviceContext context, const void *accelOptions, const void *buildInputs, unsigned int numBuildInputs, void *bufferSizes)
+{
+    TRACE("(%p, %p, %p, %u, %p)\n", context, accelOptions, buildInputs, numBuildInputs, bufferSizes);
+    return optixFunctionTable_60.optixAccelComputeMemoryUsage(context, accelOptions, buildInputs, numBuildInputs, bufferSizes);
+}
+
+static OptixResult __cdecl optixAccelBuild_60(OptixDeviceContext context, CUstream stream, const void *accelOptions, const void *buildInputs, unsigned int numBuildInputs, CUdeviceptr tempBuffer, size_t tempBufferSizeInBytes, CUdeviceptr outputBuffer, size_t outputBufferSizeInBytes, OptixTraversableHandle *outputHandle, const void *emittedProperties, unsigned int numEmittedProperties)
+{
+    TRACE("(%p, %p, %p, %p, %u, %p, %zu, %p, %zu, %p, %p, %u)\n", context, stream, accelOptions, buildInputs, numBuildInputs, tempBuffer, tempBufferSizeInBytes, outputBuffer, outputBufferSizeInBytes, outputHandle, emittedProperties, numEmittedProperties);
+    return optixFunctionTable_60.optixAccelBuild(context, stream, accelOptions, buildInputs, numBuildInputs, tempBuffer, tempBufferSizeInBytes, outputBuffer, outputBufferSizeInBytes, outputHandle, emittedProperties, numEmittedProperties);
+}
+
+static OptixResult __cdecl optixAccelGetRelocationInfo_60(OptixDeviceContext context, OptixTraversableHandle handle, void *info)
+{
+    TRACE("(%p, %llu, %p)\n", context, handle, info);
+    return optixFunctionTable_60.optixAccelGetRelocationInfo(context, handle, info);
+}
+
+static OptixResult __cdecl optixAccelCheckRelocationCompatibility_60(OptixDeviceContext context, const void *info, int *compatible)
+{
+    TRACE("(%p, %p, %p)\n", context, info, compatible);
+    return optixFunctionTable_60.optixAccelCheckRelocationCompatibility(context, info, compatible);
+}
+
+static OptixResult __cdecl optixAccelRelocate_60(OptixDeviceContext context, CUstream stream, const void *info, CUdeviceptr instanceTraversableHandles, size_t numInstanceTraversableHandles, CUdeviceptr targetAccel, size_t targetAccelSizeInBytes, OptixTraversableHandle *targetHandle)
+{
+    TRACE("(%p, %p, %p, %p, %zu, %p, %zu, %p)\n", context, stream, info, instanceTraversableHandles, numInstanceTraversableHandles, targetAccel, targetAccelSizeInBytes, targetHandle);
+    return optixFunctionTable_60.optixAccelRelocate(context, stream, info, instanceTraversableHandles, numInstanceTraversableHandles, targetAccel, targetAccelSizeInBytes, targetHandle);
+}
+
+static OptixResult __cdecl optixAccelCompact_60(OptixDeviceContext context, CUstream stream, OptixTraversableHandle inputHandle, CUdeviceptr outputBuffer, size_t outputBufferSizeInBytes, OptixTraversableHandle *outputHandle)
+{
+    TRACE("(%p, %p, %llu, %p, %zu, %p)\n", context, stream, inputHandle, outputBuffer, outputBufferSizeInBytes, outputHandle);
+    return optixFunctionTable_60.optixAccelCompact(context, stream, inputHandle, outputBuffer, outputBufferSizeInBytes, outputHandle);
+}
+
+static OptixResult __cdecl optixConvertPointerToTraversableHandle_60(OptixDeviceContext onDevice, CUdeviceptr pointer, int traversableType, OptixTraversableHandle *traversableHandle)
+{
+    TRACE("(%p, %p, %d, %p)\n", onDevice, pointer, traversableType, traversableHandle);
+    return optixFunctionTable_60.optixConvertPointerToTraversableHandle(onDevice, pointer, traversableType, traversableHandle);
+}
+
+static void __cdecl reserved1_60(void)
+{
+    TRACE("()\n");
+    optixFunctionTable_60.reserved1();
+}
+
+static void __cdecl reserved2_60(void)
+{
+    TRACE("()\n");
+    optixFunctionTable_60.reserved2();
+}
+
+static OptixResult __cdecl optixSbtRecordPackHeader_60(OptixProgramGroup programGroup, void *sbtRecordHeaderHostPointer)
+{
+    TRACE("(%p, %p)\n", programGroup, sbtRecordHeaderHostPointer);
+    return optixFunctionTable_60.optixSbtRecordPackHeader(programGroup, sbtRecordHeaderHostPointer);
+}
+
+static OptixResult __cdecl optixLaunch_60(OptixPipeline pipeline, CUstream stream, CUdeviceptr pipelineParams, size_t pipelineParamsSize, const void *sbt, unsigned int width, unsigned int height, unsigned int depth)
+{
+    TRACE("(%p, %p, %p, %zu, %p, %u, %u, %u)\n", pipeline, stream, pipelineParams, pipelineParamsSize, sbt, width, height, depth);
+    return optixFunctionTable_60.optixLaunch(pipeline, stream, pipelineParams, pipelineParamsSize, sbt, width, height, depth);
+}
+
+static OptixResult __cdecl optixDenoiserCreate_60(OptixDeviceContext context, int modelKind, const void *options, OptixDenoiser *returnHandle)
+{
+    TRACE("(%p, %d, %p, %p)\n", context, modelKind, options, returnHandle);
+    return optixFunctionTable_60.optixDenoiserCreate(context, modelKind, options, returnHandle);
+}
+
+static OptixResult __cdecl optixDenoiserDestroy_60(OptixDenoiser handle)
+{
+    TRACE("(%p)\n", handle);
+    return optixFunctionTable_60.optixDenoiserDestroy(handle);
+}
+
+static OptixResult __cdecl optixDenoiserComputeMemoryResources_60(const OptixDenoiser handle, unsigned int maximumInputWidth, unsigned int maximumInputHeight, void *returnSizes)
+{
+    TRACE("(%p, %u, %u, %p)\n", handle, maximumInputWidth, maximumInputHeight, returnSizes);
+    return optixFunctionTable_60.optixDenoiserComputeMemoryResources(handle, maximumInputWidth, maximumInputHeight, returnSizes);
+}
+
+static OptixResult __cdecl optixDenoiserSetup_60(OptixDenoiser denoiser, CUstream stream, unsigned int inputWidth, unsigned int inputHeight, CUdeviceptr state, size_t stateSizeInBytes, CUdeviceptr scratch, size_t scratchSizeInBytes)
+{
+    TRACE("(%p, %p, %u, %u, %p, %zu, %p, %zu)\n", denoiser, stream, inputWidth, inputHeight, state, stateSizeInBytes, scratch, scratchSizeInBytes);
+    return optixFunctionTable_60.optixDenoiserSetup(denoiser, stream, inputWidth, inputHeight, state, stateSizeInBytes, scratch, scratchSizeInBytes);
+}
+
+static OptixResult __cdecl optixDenoiserInvoke_60(OptixDenoiser denoiser, CUstream stream, const void *params, CUdeviceptr denoiserState, size_t denoiserStateSizeInBytes, const void *guideLayer, const void *layers, unsigned int numLayers, unsigned int inputOffsetX, unsigned int inputOffsetY, CUdeviceptr scratch, size_t scratchSizeInBytes)
+{
+    TRACE("(%p, %p, %p, %p, %zu, %p, %p, %u, %u, %u, %p, %zu)\n", denoiser, stream, params, denoiserState, denoiserStateSizeInBytes, guideLayer, layers, numLayers, inputOffsetX, inputOffsetY, scratch, scratchSizeInBytes);
+    return optixFunctionTable_60.optixDenoiserInvoke(denoiser, stream, params, denoiserState, denoiserStateSizeInBytes, guideLayer, layers, numLayers, inputOffsetX, inputOffsetY, scratch, scratchSizeInBytes);
+}
+
+static OptixResult __cdecl optixDenoiserComputeIntensity_60(OptixDenoiser handle, CUstream stream, const void *inputImage, CUdeviceptr outputIntensity, CUdeviceptr scratch, size_t scratchSizeInBytes)
+{
+    TRACE("(%p, %p, %p, %p, %p, %zu)\n", handle, stream, inputImage, outputIntensity, scratch, scratchSizeInBytes);
+    return optixFunctionTable_60.optixDenoiserComputeIntensity(handle, stream, inputImage, outputIntensity, scratch, scratchSizeInBytes);
+}
+
+static OptixResult __cdecl optixDenoiserComputeAverageColor_60(OptixDenoiser handle, CUstream stream, const void *inputImage, CUdeviceptr outputAverageColor, CUdeviceptr scratch, size_t scratchSizeInBytes)
+{
+    TRACE("(%p, %p, %p, %p, %p, %zu)\n", handle, stream, inputImage, outputAverageColor, scratch, scratchSizeInBytes);
+    return optixFunctionTable_60.optixDenoiserComputeAverageColor(handle, stream, inputImage, outputAverageColor, scratch, scratchSizeInBytes);
+}
+
+static OptixResult __cdecl optixDenoiserCreateWithUserModel_60(OptixDeviceContext context, const void *data, size_t dataSizeInBytes, OptixDenoiser *returnHandle)
+{
+    TRACE("(%p, %p, %zu, %p)\n", context, data, dataSizeInBytes, returnHandle);
+    return optixFunctionTable_60.optixDenoiserCreateWithUserModel(context, data, dataSizeInBytes, returnHandle);
+}
+
+OptixResult __cdecl optixQueryFunctionTable_60(
+    unsigned int numOptions,
+    int *optionKeys,
+    const void **optionValues,
+    void *functionTable,
+    size_t sizeOfTable)
+{
+    if (sizeOfTable != sizeof(OptixFunctionTable_60)) return OPTIX_ERROR_FUNCTION_TABLE_SIZE_MISMATCH;
+
+    OptixResult result = poptixQueryFunctionTable(60, numOptions, optionKeys, optionValues, &optixFunctionTable_60, sizeOfTable);
+
+    if (result != OPTIX_SUCCESS) return result;
+
+    OptixFunctionTable_60 *table = functionTable;
+
+    #define ASSIGN_FUNCPTR(f) *(void**)(&table->f) = (void*)&f ## _60
+
+    ASSIGN_FUNCPTR(optixGetErrorName);
+    ASSIGN_FUNCPTR(optixGetErrorString);
+    ASSIGN_FUNCPTR(optixDeviceContextCreate);
+    ASSIGN_FUNCPTR(optixDeviceContextDestroy);
+    ASSIGN_FUNCPTR(optixDeviceContextGetProperty);
+    ASSIGN_FUNCPTR(optixDeviceContextSetLogCallback);
+    ASSIGN_FUNCPTR(optixDeviceContextSetCacheEnabled);
+    ASSIGN_FUNCPTR(optixDeviceContextSetCacheLocation);
+    ASSIGN_FUNCPTR(optixDeviceContextSetCacheDatabaseSizes);
+    ASSIGN_FUNCPTR(optixDeviceContextGetCacheEnabled);
+    ASSIGN_FUNCPTR(optixDeviceContextGetCacheLocation);
+    ASSIGN_FUNCPTR(optixDeviceContextGetCacheDatabaseSizes);
+    ASSIGN_FUNCPTR(optixModuleCreateFromPTX);
+    ASSIGN_FUNCPTR(optixModuleCreateFromPTXWithTasks);
+    ASSIGN_FUNCPTR(optixModuleGetCompilationState);
+    ASSIGN_FUNCPTR(optixModuleDestroy);
+    ASSIGN_FUNCPTR(optixBuiltinISModuleGet);
+    ASSIGN_FUNCPTR(optixTaskExecute);
+    ASSIGN_FUNCPTR(optixProgramGroupCreate);
+    ASSIGN_FUNCPTR(optixProgramGroupDestroy);
+    ASSIGN_FUNCPTR(optixProgramGroupGetStackSize);
+    ASSIGN_FUNCPTR(optixPipelineCreate);
+    ASSIGN_FUNCPTR(optixPipelineDestroy);
+    ASSIGN_FUNCPTR(optixPipelineSetStackSize);
+    ASSIGN_FUNCPTR(optixAccelComputeMemoryUsage);
+    ASSIGN_FUNCPTR(optixAccelBuild);
+    ASSIGN_FUNCPTR(optixAccelGetRelocationInfo);
+    ASSIGN_FUNCPTR(optixAccelCheckRelocationCompatibility);
+    ASSIGN_FUNCPTR(optixAccelRelocate);
+    ASSIGN_FUNCPTR(optixAccelCompact);
+    ASSIGN_FUNCPTR(optixConvertPointerToTraversableHandle);
+    ASSIGN_FUNCPTR(reserved1);
+    ASSIGN_FUNCPTR(reserved2);
+    ASSIGN_FUNCPTR(optixSbtRecordPackHeader);
+    ASSIGN_FUNCPTR(optixLaunch);
+    ASSIGN_FUNCPTR(optixDenoiserCreate);
+    ASSIGN_FUNCPTR(optixDenoiserDestroy);
+    ASSIGN_FUNCPTR(optixDenoiserComputeMemoryResources);
+    ASSIGN_FUNCPTR(optixDenoiserSetup);
+    ASSIGN_FUNCPTR(optixDenoiserInvoke);
+    ASSIGN_FUNCPTR(optixDenoiserComputeIntensity);
+    ASSIGN_FUNCPTR(optixDenoiserComputeAverageColor);
+    ASSIGN_FUNCPTR(optixDenoiserCreateWithUserModel);
+
+    #undef ASSIGN_FUNCPTR
+
+    return OPTIX_SUCCESS;
+}
+

--- a/src/nvoptix_60.h
+++ b/src/nvoptix_60.h
@@ -1,0 +1,85 @@
+ /*
+ * Copyright (c) 2021 NVIDIA Corporation.  All rights reserved.
+ *
+ * NVIDIA Corporation and its licensors retain all intellectual property and proprietary
+ * rights in and to this software, related documentation and any modifications thereto.
+ * Any use, reproduction, disclosure or distribution of this software and related
+ * documentation without an express license agreement from NVIDIA Corporation is strictly
+ * prohibited.
+ *
+ * TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THIS SOFTWARE IS PROVIDED *AS IS*
+ * AND NVIDIA AND ITS SUPPLIERS DISCLAIM ALL WARRANTIES, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.  IN NO EVENT SHALL NVIDIA OR ITS SUPPLIERS BE LIABLE FOR ANY
+ * SPECIAL, INCIDENTAL, INDIRECT, OR CONSEQUENTIAL DAMAGES WHATSOEVER (INCLUDING, WITHOUT
+ * LIMITATION, DAMAGES FOR LOSS OF BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS OF
+ * BUSINESS INFORMATION, OR ANY OTHER PECUNIARY LOSS) ARISING OUT OF THE USE OF OR
+ * INABILITY TO USE THIS SOFTWARE, EVEN IF NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGES
+ */
+
+#pragma once
+
+#include "nvoptix.h"
+#include <stddef.h>
+
+// defensive duplicate of OptixDeviceContextOptions because I have to modify it
+
+typedef struct OptixDeviceContextOptions_60
+{
+    OptixLogCallback logCallbackFunction;
+    void *logCallbackData;
+    int logCallbackLevel;
+    int validationMode;
+} OptixDeviceContextOptions_60;
+
+// table as in public docs but stripped of most structures (pointers to which have been replaced with opaque `void*`)
+
+typedef struct OptixFunctionTable_60
+{
+    const char *(*optixGetErrorName)(OptixResult result);
+    const char *(*optixGetErrorString)(OptixResult result);
+    OptixResult (*optixDeviceContextCreate)(CUcontext fromContext, const OptixDeviceContextOptions_60 *options, OptixDeviceContext *context);
+    OptixResult (*optixDeviceContextDestroy)(OptixDeviceContext context);
+    OptixResult (*optixDeviceContextGetProperty)(OptixDeviceContext context, int property, void *value, size_t sizeInBytes);
+    OptixResult (*optixDeviceContextSetLogCallback)(OptixDeviceContext context, OptixLogCallback callbackFunction, void *callbackData, unsigned int callbackLevel);
+    OptixResult (*optixDeviceContextSetCacheEnabled)(OptixDeviceContext context, int enabled);
+    OptixResult (*optixDeviceContextSetCacheLocation)(OptixDeviceContext context, const char *location);
+    OptixResult (*optixDeviceContextSetCacheDatabaseSizes)(OptixDeviceContext context, size_t lowWaterMark, size_t highWaterMark);
+    OptixResult (*optixDeviceContextGetCacheEnabled)(OptixDeviceContext context, int *enabled);
+    OptixResult (*optixDeviceContextGetCacheLocation)(OptixDeviceContext context, char *location, size_t locationSize);
+    OptixResult (*optixDeviceContextGetCacheDatabaseSizes)(OptixDeviceContext context, size_t *lowWaterMark, size_t *highWaterMark);
+    OptixResult (*optixModuleCreateFromPTX)(OptixDeviceContext context, const void *moduleCompileOptions, const void *pipelineCompileOptions, const char *PTX, size_t PTXsize, char *logString, size_t *logStringSize, OptixModule *module);
+    OptixResult (*optixModuleCreateFromPTXWithTasks)(OptixDeviceContext context, const void *moduleCompileOptions, const void *pipelineCompileOptions, const char *PTX, size_t PTXsize, char *logString, size_t *logStringSize, OptixModule *module, OptixTask *firstTask);
+    OptixResult (*optixModuleGetCompilationState)(OptixModule module, int *state);
+    OptixResult (*optixModuleDestroy)(OptixModule module);
+    OptixResult (*optixBuiltinISModuleGet)(OptixDeviceContext context, const void *moduleCompileOptions, const void *pipelineCompileOptions, const void *builtinISOptions, OptixModule *builtinModule);
+    OptixResult (*optixTaskExecute)(OptixTask task, OptixTask *additionalTasks, unsigned int maxNumAdditionalTasks, unsigned int *numAdditionalTasksCreated);
+    OptixResult (*optixProgramGroupCreate)(OptixDeviceContext context, const void *programDescriptions, unsigned int numProgramGroups, const void *options, char *logString, size_t *logStringSize, OptixProgramGroup *programGroups);
+    OptixResult (*optixProgramGroupDestroy)(OptixProgramGroup programGroup);
+    OptixResult (*optixProgramGroupGetStackSize)(OptixProgramGroup programGroup, void *stackSizes);
+    OptixResult (*optixPipelineCreate)(OptixDeviceContext context, const void *pipelineCompileOptions, const void *pipelineLinkOptions, const OptixProgramGroup *programGroups, unsigned int numProgramGroups, char *logString, size_t *logStringSize, OptixPipeline *pipeline);
+    OptixResult (*optixPipelineDestroy)(OptixPipeline pipeline);
+    OptixResult (*optixPipelineSetStackSize)(OptixPipeline pipeline, unsigned int directCallableStackSizeFromTraversal, unsigned int directCallableStackSizeFromState, unsigned int continuationStackSize, unsigned int maxTraversableGraphDepth);
+    OptixResult (*optixAccelComputeMemoryUsage)(OptixDeviceContext context, const void *accelOptions, const void *buildInputs, unsigned int numBuildInputs, void *bufferSizes);
+    OptixResult (*optixAccelBuild)(OptixDeviceContext context, CUstream stream, const void *accelOptions, const void *buildInputs, unsigned int numBuildInputs, CUdeviceptr tempBuffer, size_t tempBufferSizeInBytes, CUdeviceptr outputBuffer, size_t outputBufferSizeInBytes, OptixTraversableHandle *outputHandle, const void *emittedProperties, unsigned int numEmittedProperties);
+    OptixResult (*optixAccelGetRelocationInfo)(OptixDeviceContext context, OptixTraversableHandle handle, void *info);
+    OptixResult (*optixAccelCheckRelocationCompatibility)(OptixDeviceContext context, const void *info, int *compatible);
+    OptixResult (*optixAccelRelocate)(OptixDeviceContext context, CUstream stream, const void *info, CUdeviceptr instanceTraversableHandles, size_t numInstanceTraversableHandles, CUdeviceptr targetAccel, size_t targetAccelSizeInBytes, OptixTraversableHandle *targetHandle);
+    OptixResult (*optixAccelCompact)(OptixDeviceContext context, CUstream stream, OptixTraversableHandle inputHandle, CUdeviceptr outputBuffer, size_t outputBufferSizeInBytes, OptixTraversableHandle *outputHandle);
+    OptixResult (*optixConvertPointerToTraversableHandle)(OptixDeviceContext onDevice, CUdeviceptr pointer, int traversableType, OptixTraversableHandle *traversableHandle);
+    void (*reserved1)(void);
+    void (*reserved2)(void);
+    OptixResult (*optixSbtRecordPackHeader)(OptixProgramGroup programGroup, void *sbtRecordHeaderHostPointer);
+    OptixResult (*optixLaunch)(OptixPipeline pipeline, CUstream stream, CUdeviceptr pipelineParams, size_t pipelineParamsSize, const void *sbt, unsigned int width, unsigned int height, unsigned int depth);
+    OptixResult (*optixDenoiserCreate)(OptixDeviceContext context, int modelKind, const void *options, OptixDenoiser *returnHandle);
+    OptixResult (*optixDenoiserDestroy)(OptixDenoiser handle);
+    OptixResult (*optixDenoiserComputeMemoryResources)(const OptixDenoiser handle, unsigned int maximumInputWidth, unsigned int maximumInputHeight, void *returnSizes);
+    OptixResult (*optixDenoiserSetup)(OptixDenoiser denoiser, CUstream stream, unsigned int inputWidth, unsigned int inputHeight, CUdeviceptr state, size_t stateSizeInBytes, CUdeviceptr scratch, size_t scratchSizeInBytes);
+    OptixResult (*optixDenoiserInvoke)(OptixDenoiser denoiser, CUstream stream, const void *params, CUdeviceptr denoiserState, size_t denoiserStateSizeInBytes, const void *guideLayer, const void *layers, unsigned int numLayers, unsigned int inputOffsetX, unsigned int inputOffsetY, CUdeviceptr scratch, size_t scratchSizeInBytes);
+    OptixResult (*optixDenoiserComputeIntensity)(OptixDenoiser handle, CUstream stream, const void *inputImage, CUdeviceptr outputIntensity, CUdeviceptr scratch, size_t scratchSizeInBytes);
+    OptixResult (*optixDenoiserComputeAverageColor)(OptixDenoiser handle, CUstream stream, const void *inputImage, CUdeviceptr outputAverageColor, CUdeviceptr scratch, size_t scratchSizeInBytes);
+    OptixResult (*optixDenoiserCreateWithUserModel)(OptixDeviceContext context, const void *data, size_t dataSizeInBytes, OptixDenoiser *returnHandle);
+} OptixFunctionTable_60;
+
+OptixResult __cdecl optixQueryFunctionTable_60(unsigned int numOptions, int *optionKeys, const void **optionValues, void *functionTable, size_t sizeOfTable);


### PR DESCRIPTION
Add support for SDK 7.5 (ABI 60).

It did not seem to be any function changes between 55 -> 60. Some struct changes, but afaik we use voids for that and should not be affected by that.

Tested a few SDK samples that were compiled with CUDA 11.4. OptiX SDK 7.5 defaults to using CUDA 11.7, but that is not supported by wine nvcuda so far, so i cannot verify if there is any functions not working there.